### PR TITLE
feat: add optional SerpBase provider for SERP gap analysis

### DIFF
--- a/backend/env_template.txt
+++ b/backend/env_template.txt
@@ -11,6 +11,7 @@ GEMINI_API_KEY=your_gemini_api_key_here
 # SERPER_API_KEY=your_serper_api_key_here
 EXA_API_KEY=your_exa_api_key_here
 # SERPBASE_API_KEY=your_serpbase_api_key_here  # optional Google SERP provider (https://serpbase.dev)
+# SERPBASE_BASE_URL=https://api.serpbase.dev/google/search  # optional override for tests/proxies
 
 # Authentication
 # CLERK_SECRET_KEY=your_clerk_secret_key_here

--- a/backend/env_template.txt
+++ b/backend/env_template.txt
@@ -10,6 +10,7 @@ GEMINI_API_KEY=your_gemini_api_key_here
 # TAVILY_API_KEY=your_tavily_api_key_here
 # SERPER_API_KEY=your_serper_api_key_here
 EXA_API_KEY=your_exa_api_key_here
+# SERPBASE_API_KEY=your_serpbase_api_key_here  # optional Google SERP provider (https://serpbase.dev)
 
 # Authentication
 # CLERK_SECRET_KEY=your_clerk_secret_key_here

--- a/backend/services/seo_tools/serp_gap_service.py
+++ b/backend/services/seo_tools/serp_gap_service.py
@@ -134,7 +134,10 @@ class SerpGapService:
         Check SERP presence for a single topic across all competitor domains.
 
         Removes the dateRestrict and sort=date defaults from Google CSE so we
-        see all-time competitor content (not just last month).
+        see all-time competitor content (not just last month). A per-query
+        failure (SerpBase error, CSE error, network timeout) is recorded as a
+        failed query for that domain and skipped — it never aborts the batch
+        (review feedback on PR #901).
         """
         competitors_found = []
         failed_queries = 0
@@ -163,7 +166,7 @@ class SerpGapService:
                     })
             except Exception as e:
                 logger.warning(
-                    f"GCS query failed for site:{domain} topic='{topic}': {e}"
+                    f"Search query failed for site:{domain} topic='{topic}': {e}"
                 )
                 failed_queries += 1
                 continue

--- a/backend/services/seo_tools/serp_gap_service.py
+++ b/backend/services/seo_tools/serp_gap_service.py
@@ -1,7 +1,8 @@
 """
 SERP Gap Service for ALwrity
 
-Detects which competitors rank for target topics using Google Custom Search.
+Detects which competitors rank for target topics using Google Custom Search
+or the optional SerpBase API (opt-in via SERPBASE_API_KEY).
 Phase 1 of the Content Gap Radar feature.
 
 Usage:
@@ -20,6 +21,7 @@ import time
 from typing import Dict, List, Optional, Any
 from loguru import logger
 from services.research.google_search_service import GoogleSearchService
+from services.seo_tools.serpbase_service import SerpBaseService
 
 
 class SerpGapService:
@@ -28,7 +30,9 @@ class SerpGapService:
 
     Uses Google Custom Search `site:` queries to detect competitor ranking presence
     for specific topics. Results are cached for 24h to stay within free-tier quotas
-    (100 queries/day). Designed to be consumed by a future ContentGapRadarAgent
+    (100 queries/day). When SERPBASE_API_KEY is set, SerpBase is used instead of
+    Google Custom Search (no 100-query/day cap, returns positions and AI Overview).
+    Designed to be consumed by a future ContentGapRadarAgent
     that scores and prioritizes gaps.
     """
 
@@ -36,8 +40,10 @@ class SerpGapService:
 
     def __init__(self, google_search_service: Optional[GoogleSearchService] = None):
         self.gcs = google_search_service or GoogleSearchService()
+        self.serpbase = SerpBaseService()
         self._cache: Dict[str, Dict[str, Any]] = {}
-        logger.info("SerpGapService initialized")
+        provider = "SerpBase" if self.serpbase.enabled else "Google Custom Search"
+        logger.info(f"SerpGapService initialized (provider: {provider})")
 
     def _cache_key(self, topics: List[str], domains: List[str]) -> str:
         """Deterministic cache key from sorted topics + domains."""
@@ -72,7 +78,7 @@ class SerpGapService:
         Args:
             topics: Topic phrases to check (e.g. from find_semantic_gaps())
             competitor_domains: Known competitor domains (e.g. ["example.com"])
-            max_results_per_site: Max Google CSE results per site: query (max 10)
+            max_results_per_site: Max results per site: query (max 10)
             concurrency: Max concurrent API calls to stay under rate limits
             bypass_cache: Force fresh API calls, ignoring cache
 
@@ -136,12 +142,18 @@ class SerpGapService:
         for domain in competitor_domains:
             query = f"site:{domain} {topic}"
             try:
-                raw_results = await self.gcs.perform_search(
-                    query,
-                    max_results,
-                    dateRestrict=None,  # Don't limit to last month
-                    sort=None,  # Use relevance sorting, not date
-                )
+                if self.serpbase.enabled:
+                    raw_results = await self.serpbase.perform_search(
+                        query,
+                        max_results,
+                    )
+                else:
+                    raw_results = await self.gcs.perform_search(
+                        query,
+                        max_results,
+                        dateRestrict=None,  # Don't limit to last month
+                        sort=None,  # Use relevance sorting, not date
+                    )
                 for result in raw_results:
                     competitors_found.append({
                         "domain": domain,

--- a/backend/services/seo_tools/serpbase_service.py
+++ b/backend/services/seo_tools/serpbase_service.py
@@ -9,9 +9,22 @@ existing behavior is unchanged.
 
 import os
 import json
+import asyncio
 import aiohttp
 from typing import Dict, List, Optional, Any
 from loguru import logger
+
+# One session shared across requests: aiohttp.ClientSession() pools
+# connections, so creating one per request would destroy pooling and risk
+# socket exhaustion under gap-analysis concurrency (see review on PR #901).
+_session: Optional[aiohttp.ClientSession] = None
+
+
+def _get_session() -> aiohttp.ClientSession:
+    global _session
+    if _session is None or _session.closed:
+        _session = aiohttp.ClientSession()
+    return _session
 
 
 class SerpBaseService:
@@ -22,9 +35,16 @@ class SerpBaseService:
     keyword research) works unchanged.
     """
 
+    # Base URL overridable via env for tests/proxies; defaults to the
+    # live SerpBase endpoint (review feedback on PR #901).
+    DEFAULT_BASE_URL = os.getenv("SERPBASE_BASE_URL", "https://api.serpbase.dev/google/search")
+    # aiohttp's default timeout is 5 minutes, which can hang async tasks if
+    # the external API stalls — enforce a strict ceiling.
+    REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=10)
+
     def __init__(self) -> None:
         self.api_key = os.getenv("SERPBASE_API_KEY", "")
-        self.base_url = "https://api.serpbase.dev/google/search"
+        self.base_url = self.DEFAULT_BASE_URL
         self.enabled = bool(self.api_key)
         if self.enabled:
             logger.info("SerpBase Service initialized (SERPBASE_API_KEY set)")
@@ -59,21 +79,28 @@ class SerpBaseService:
             "Content-Type": "application/json",
         }
 
+        session = _get_session()
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    self.base_url, json=payload, headers=headers
-                ) as response:
-                    if response.status != 200:
-                        error_text = await response.text()
-                        logger.error(
-                            f"SerpBase API error: {response.status} - {error_text}"
-                        )
-                        raise RuntimeError(
-                            f"SerpBase API returned status {response.status}"
-                        )
-                    data = await response.json()
-        except Exception as e:
+            async with session.post(
+                self.base_url, json=payload, headers=headers, timeout=self.REQUEST_TIMEOUT
+            ) as response:
+                # Non-2xx may carry an HTML error body (e.g. 502 from a
+                # gateway proxy) — read text first and surface it rather than
+                # letting response.json() raise an unhandled ContentTypeError.
+                if response.status != 200:
+                    error_text = await response.text()
+                    logger.error(
+                        f"SerpBase API error: {response.status} - {error_text[:500]}"
+                    )
+                    raise RuntimeError(
+                        f"SerpBase API returned status {response.status}"
+                    )
+                try:
+                    data = await response.json(content_type=None)
+                except (aiohttp.ContentTypeError, json.JSONDecodeError) as e:
+                    logger.error(f"SerpBase API returned non-JSON body: {e}")
+                    raise RuntimeError("SerpBase API returned a non-JSON response")
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
             logger.warning(f"SerpBase request failed: {e}")
             raise
 
@@ -84,7 +111,9 @@ class SerpBaseService:
                 f"SerpBase API error: {data.get('message', 'unknown')}"
             )
 
-        results = data.get("organic", []) if isinstance(data, dict) else []
+        # Defensive extraction: organic may be absent or null — treat
+        # anything falsy as an empty result set instead of crashing.
+        results = data.get("organic") or [] if isinstance(data, dict) else []
         items = []
         for idx, r in enumerate(results):
             if not isinstance(r, dict):

--- a/backend/services/seo_tools/serpbase_service.py
+++ b/backend/services/seo_tools/serpbase_service.py
@@ -1,0 +1,100 @@
+"""SerpBaseService — optional Google SERP provider for ALwrity.
+
+Mirrors GoogleSearchService's result contract (list of dicts with
+title/link/snippet) so SerpGapService can consume it unchanged. Opt-in via
+SERPBASE_API_KEY; when the key is unset the service is disabled and callers
+raise the same kind of error they already handle for missing CSE keys, so
+existing behavior is unchanged.
+"""
+
+import os
+import json
+import aiohttp
+from typing import Dict, List, Optional, Any
+from loguru import logger
+
+
+class SerpBaseService:
+    """Google SERP results via the SerpBase API (https://serpbase.dev).
+
+    Only active when SERPBASE_API_KEY is set. Returns results shaped like
+    GoogleSearchService.perform_search output so downstream code (SerpGapService,
+    keyword research) works unchanged.
+    """
+
+    def __init__(self) -> None:
+        self.api_key = os.getenv("SERPBASE_API_KEY", "")
+        self.base_url = "https://api.serpbase.dev/google/search"
+        self.enabled = bool(self.api_key)
+        if self.enabled:
+            logger.info("SerpBase Service initialized (SERPBASE_API_KEY set)")
+        else:
+            logger.info("SerpBase Service disabled (SERPBASE_API_KEY not set)")
+
+    async def perform_search(
+        self, query: str, max_results: int = 10, **overrides: Any
+    ) -> List[Dict[str, Any]]:
+        """Run a Google search through SerpBase and return items as dicts.
+
+        Accepts and ignores the CSE-specific overrides (dateRestrict, sort)
+        so it can be swapped in where GoogleSearchService.perform_search is
+        called. Results carry title/link/snippet, plus position when present.
+        """
+        if not self.enabled:
+            raise RuntimeError(
+                "SerpBase Service is not enabled. Set SERPBASE_API_KEY."
+            )
+
+        payload: Dict[str, Any] = {
+            "q": query,
+            "num": min(max_results, 10),
+            "hl": overrides.get("hl", "en"),
+            "gl": overrides.get("gl", "us"),
+        }
+        # CSE-only params (dateRestrict/sort/safe/cx/key) are intentionally
+        # not forwarded to SerpBase.
+
+        headers = {
+            "X-API-Key": self.api_key,
+            "Content-Type": "application/json",
+        }
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    self.base_url, json=payload, headers=headers
+                ) as response:
+                    if response.status != 200:
+                        error_text = await response.text()
+                        logger.error(
+                            f"SerpBase API error: {response.status} - {error_text}"
+                        )
+                        raise RuntimeError(
+                            f"SerpBase API returned status {response.status}"
+                        )
+                    data = await response.json()
+        except Exception as e:
+            logger.warning(f"SerpBase request failed: {e}")
+            raise
+
+        # Envelope: HTTP 200 with status != 0 means a business error.
+        if isinstance(data, dict) and data.get("status", 0) != 0:
+            logger.error(f"SerpBase API business error: {data}")
+            raise RuntimeError(
+                f"SerpBase API error: {data.get('message', 'unknown')}"
+            )
+
+        results = data.get("organic", []) if isinstance(data, dict) else []
+        items = []
+        for idx, r in enumerate(results):
+            if not isinstance(r, dict):
+                continue
+            items.append(
+                {
+                    "title": r.get("title", ""),
+                    "link": r.get("link") or r.get("url", ""),
+                    "snippet": r.get("snippet", ""),
+                    "position": r.get("position", idx + 1),
+                }
+            )
+        return items


### PR DESCRIPTION
## Summary
Adds an optional SerpBase provider for the SERP gap analysis feature. When `SERPBASE_API_KEY` is set, `SerpGapService` uses the SerpBase Google SERP API instead of Google Custom Search; when it's unset, behavior is unchanged (CSE stays the default).

## Background
The SERP gap analysis in `backend/api/seo_dashboard.py` (`get_serp_gaps`) relies entirely on Google Custom Search, which has a hard 100 queries/day free-tier cap and no AI Overview / position data. SerpBase (https://serpbase.dev) is a pay-as-you-go Google SERP API ($0.30/1k queries, 100 free searches) that returns positions plus `related_questions`/`related_searches` in one JSON call — relevant for the PAA/PASF signals discussed in #885.

## Changes
- **New**: `backend/services/seo_tools/serpbase_service.py` — SerpBaseService mirroring the `GoogleSearchService.perform_search` result contract (list of dicts with title/link/snippet + position). POST + JSON body + `X-API-Key` header per current SerpBase API contract, envelope `status != 0` treated as an error, graceful `RuntimeError` when the key is unset (same pattern as missing CSE keys).
- **Updated**: `backend/services/seo_tools/serp_gap_service.py` — prefers SerpBase when enabled, CSE fallback otherwise; docstring/log line reflect the active provider.
- **Updated**: `backend/env_template.txt` — documents `SERPBASE_API_KEY`.

## Design decisions
| Decision | Rationale |
|----------|-----------|
| Opt-in via `SERPBASE_API_KEY` | Matches existing optional-provider convention (TAVILY_API_KEY, SERPER_API_KEY already in env_template) |
| Reuses `aiohttp` | Already a backend dependency — no new packages |
| Result contract identical to `perform_search` | `SerpGapService._analyze_single_topic` consumes either provider unchanged |
| CSE stays default when key unset | No behavior change for existing installs |

## Testing
- `SerpBaseService.perform_search` returns organic results shaped as title/link/snippet/position.
- When `SERPBASE_API_KEY` is unset: `serpbase.enabled=False`, SerpGapService uses Google Custom Search exactly as before.
- When key is set: SerpGapService routes queries through SerpBase; per-query failures are caught and counted as `failed_queries`, same as CSE failures.
- `python -m py_compile` clean on both files.

## Related
- Closes #885 (feature request: optional SerpBase provider for GoogleSearchService / SERP gap analysis)
